### PR TITLE
Include CA root certificates in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go get golang.org/x/vgo
 RUN make clean compile
 
 FROM alpine:3.8
-RUN apk add --no-cache nfs-utils qemu-img
+RUN apk add --no-cache nfs-utils qemu-img ca-certificates
 WORKDIR /bin/
 COPY --from=0 /go/src/github.com/hammerspace/hammerspace-csi-plugin/bin/hs-csi-plugin .
 ENTRYPOINT ["/bin/hs-csi-plugin"]


### PR DESCRIPTION
Allows for HS_TLS_VERIFY=true.

Error changed from:
"x509: failed to load system roots and no roots provided"

To:
"x509: certificate is valid for X, not Y"