### PR TITLE
Use an older version of the alpine container that uses rpc v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /go/src/github.com/hammer-space/csi-plugin/
 ADD . ./
 RUN make clean compile
 
-FROM alpine:3.9
+FROM alpine:3.6
 # Install required packages
 RUN apk add --no-cache nfs-utils qemu-img ca-certificates xfsprogs e2fsprogs e2fsprogs-extra xfsprogs-extra zfs btrfs-progs py-pip
 RUN pip install hstk


### PR DESCRIPTION
rpc v3/4 causes showmount issues with the portal's NAT.

 A description of a similar problem can be found here:
 https://www.suse.com/support/kb/doc/?id=000019425