### PR TITLE
gRPC: Don't close the connection after 5 minutes idle time

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -128,7 +128,7 @@ func (c *CSIDriver) Start(l net.Listener) error {
     c.server = grpc.NewServer(
         grpc.UnaryInterceptor(c.callInterceptor),
         grpc.KeepaliveParams(keepalive.ServerParameters{
-            MaxConnectionIdle: 5 * time.Minute,
+            Time: 5 * time.Minute,
         }),
     )
 

--- a/pkg/driver/driver_csi_v0.go
+++ b/pkg/driver/driver_csi_v0.go
@@ -76,7 +76,7 @@ func (c *CSIDriver_v0Support) Start(l net.Listener) error {
     c.server = grpc.NewServer(
         grpc.UnaryInterceptor(c.callInterceptor),
         grpc.KeepaliveParams(keepalive.ServerParameters{
-            MaxConnectionIdle: 5 * time.Minute,
+            Time: 5 * time.Minute,
         }),
     )
 


### PR DESCRIPTION
Set the keepalive heartbeat to 5 minutes rather than forcing a close
after 5 minutes. The latter causes the CSI driver to crash.

Signed-off-by: Trond Myklebust <trond.myklebust@hammerspace.com>