### PR TITLE
Honor fqdn StorageClass param when Anvil returns no data-portals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Treated all known terminal task states consistently so failed, halted, cancelled, validation-failed, and resumed tasks stop polling and report failure.
 - Avoided passing StorageClass NFS mount options to local filesystem mounts for file-backed volumes; those options are now only used for the backing NFS share mount.
 - Prevented duplicate or conflicting NFS version mount flags by treating both `nfsvers=` and `vers=` as version options, removing them before fallback retries, and passing NFSv3 fallback options as separate mount arguments.
+- Honored the StorageClass `fqdn` parameter in deployments without data-portals (e.g. Anvil-only/no-DSX). Previously the resolved FQDN/floating IP was discarded because the mount loops only ran per data-portal, so an empty `data-portals` list caused provisioning to fail with `could not mount to any data-portals`.
 
 ### Changed
 - Removed the driver-specific `clientMountOptions` StorageClass parameter; CSI node mounts now rely on Kubernetes `mountOptions` / CSI `mountFlags`.

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -309,6 +309,26 @@ func (d *CSIDriver) MountShareAtBestDataportal(ctx context.Context, shareExportP
 		}
 	}
 
+	// In a no-DSX deployment (e.g. Anvil-only) GetDataPortals returns an empty
+	// list, so the portal-bounded mount loops below would never execute and the
+	// resolved fipaddr (from the FQDN or floating IP) would be silently thrown
+	// away. Synthesize a single portal from fipaddr so the existing mount logic
+	// (export discovery via showmount, NFS 4.2 -> 3 fallback) still runs.
+	if len(portals) == 0 && fipaddr != "" {
+		log.Infof("No data-portals returned by Anvil; using resolved address %s as the mount target", fipaddr)
+		portals = []common.DataPortal{
+			{
+				Node: common.DataPortalNode{
+					Name: fqdn,
+					MgmtIpAddress: common.DataPortalNodeAddress{
+						Address: fipaddr,
+					},
+				},
+				Uoid: map[string]string{"uuid": fipaddr},
+			},
+		}
+	}
+
 	MountToDataPortal := func(portal common.DataPortal, mount_options []string) bool {
 		addr := ""
 		if len(fipaddr) > 0 {


### PR DESCRIPTION
## Summary

In a no-DSX deployment (Anvil-only; storage nodes registered as NODE/OTHER), `GET /mgmt/v1.2/rest/data-portals/` returns `[]`. In `MountShareAtBestDataportal` the address resolved from the StorageClass `fqdn` parameter (or the floating IP) was only ever consumed **inside** the per-data-portal mount loops. With an empty portals list those loops have zero iterations, so the resolved address is silently discarded and the driver fails with `could not mount to any data-portals`.

This broke file-backed PVC provisioning in any DSX-less environment — even when the user supplied `fqdn:`, which is the exact escape hatch that parameter is meant to be.

## Fix

When `GetDataPortals` returns an empty list but an address was resolved, synthesize a single `DataPortal` from that address so the existing mount logic (showmount export discovery, NFS 4.2 → 3 fallback) runs against it. This mirrors the FQDN-first handling already present in `EnsureRootExportMounted`.

## Scope

- `pkg/driver/utils.go` — `MountShareAtBestDataportal` (+20 lines)
- `CHANGELOG.md` — one entry under `[1.2.9] > Fixed`

No behavior change when data-portals are present (the synthesis only triggers on an empty list). Also covers the floating-IP-but-no-portals case.

## Testing

- `make compile` succeeds (static binary, v1.2.9).
- Driver unit tests pass (pre-existing unrelated `TestAcquireVolumeLockTimeout` failure aside).
- Built image and confirmed the fix is present in the shipped binary.