### PR TITLE
Configurable LOG_LEVEL with a usable INFO default (re-leveling + JSON logs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `deploy/kubernetes/kubernetes-1.3{4,5,6}/plugin.yaml` — manifests for the currently supported k8s minors, validated end-to-end on live 1.34 and 1.35 clusters (1.29 base + host-networked metrics port + OTel env vars).
 - `deploy/monitoring/` — importable Grafana dashboard (`hs-csi-driver`), an example VictoriaMetrics/Prometheus scrape config, and a wiring README.
 - Unit tests for `objectiveTarget` parsing, the file-backed size gates, the file/share volume-ID discriminator, the Anvil route-template normalization, `MeasureOp`, and the lock-timeout→`codes.Aborted` behavior.
+- `LOG_LEVEL` environment variable to set log verbosity (`panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`). Unset or unrecognized values fall back to `info`.
 
 ### Changed
+- **The driver now logs at `info` by default instead of `debug`.** Debug logging was hardcoded, so every deployment logged every Anvil REST call regardless of configuration. Set `LOG_LEVEL=debug` to restore the previous verbosity when troubleshooting.
 - Parallelized file-backed CreateVolume by narrowing the per-backing-share lock, plus `mkfs` tuning (ext4 lazy-init, `mkfs.xfs -K` over NFS). See `docs/file-backed-performance.md`.
 - Decide file- vs share-backed structurally from the volume ID instead of a `GetShare` probe that 404s for file-backed sources.
 - Task-completion polling uses a fixed 2s/30s-then-4s cadence instead of exponential backoff. See `docs/tunable-retry-parameters.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **The driver now logs at `info` by default instead of `debug`.** Debug logging was hardcoded, so every deployment logged every Anvil REST call regardless of configuration. Set `LOG_LEVEL=debug` to restore the previous verbosity when troubleshooting.
 - Log entries are now emitted as one JSON object per line instead of pretty-printed across multiple indented lines, so log collectors that parse container output line by line (Loki, ELK, CloudWatch) can ingest them.
+- Re-leveled 32 log statements so `info` is a usable default. Share create/delete/resize, objective-set, volume publish, and filesystem format are now logged at `info` — previously they were `debug`, so the record of what the driver changed on the Anvil was invisible at any other level. Conversely, per-request tracing, data-portal export probing, and function-entry traces moved to `debug`; the per-request trace line in particular was logged at `info` (and `warn` when no span context was present), so it defeated the purpose of running below `debug`.
 - Parallelized file-backed CreateVolume by narrowing the per-backing-share lock, plus `mkfs` tuning (ext4 lazy-init, `mkfs.xfs -K` over NFS). See `docs/file-backed-performance.md`.
 - Decide file- vs share-backed structurally from the volume ID instead of a `GetShare` probe that 404s for file-backed sources.
 - Task-completion polling uses a fixed 2s/30s-then-4s cadence instead of exponential backoff. See `docs/tunable-retry-parameters.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **The driver now logs at `info` by default instead of `debug`.** Debug logging was hardcoded, so every deployment logged every Anvil REST call regardless of configuration. Set `LOG_LEVEL=debug` to restore the previous verbosity when troubleshooting.
+- Log entries are now emitted as one JSON object per line instead of pretty-printed across multiple indented lines, so log collectors that parse container output line by line (Loki, ELK, CloudWatch) can ingest them.
 - Parallelized file-backed CreateVolume by narrowing the per-backing-share lock, plus `mkfs` tuning (ext4 lazy-init, `mkfs.xfs -K` over NFS). See `docs/file-backed-performance.md`.
 - Decide file- vs share-backed structurally from the volume ID instead of a `GetShare` probe that 404s for file-backed sources.
 - Task-completion polling uses a fixed 2s/30s-then-4s cadence instead of exponential backoff. See `docs/tunable-retry-parameters.md`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Variable                       |     Default           | Description
 ``HS_TLS_VERIFY``              |     ``false``         | Whether to validate the Hammerspace API gateway certificates
 ``HS_DATA_PORTAL_MOUNT_PREFIX``|                       | Override the prefix for data portal mounts. Ex ``/mnt/data-portal``
 ``CSI_MAJOR_VERSION``          |     ``"1"``           | CSI interface compatibility mode. Use ``"1"`` for Kubernetes 1.13+ deployments and ``"0"`` only for legacy Kubernetes 1.10-1.12 environments.
+``LOG_LEVEL``                  |     ``info``          | Log verbosity: ``panic``, ``fatal``, ``error``, ``warn``, ``info``, ``debug``, or ``trace``. ``debug`` logs every Anvil REST call, so use it for troubleshooting rather than steady-state operation. An unrecognized value falls back to ``info``.
 
 ## Usage
 Supported volume parameters for CreateVolume requests (maps to Kubernetes storage class params):

--- a/deploy/kubernetes/kubernetes-1.34/plugin.yaml
+++ b/deploy/kubernetes/kubernetes-1.34/plugin.yaml
@@ -156,6 +156,11 @@ spec:
               value: "false"
             - name: CSI_MAJOR_VERSION
               value: "1"
+            # Log verbosity: panic, fatal, error, warn, info, debug, trace.
+            # debug logs every Anvil REST call — use it for troubleshooting,
+            # not steady-state operation.
+            - name: LOG_LEVEL
+              value: "info"
             # OTel toggles — Prometheus /metrics on :9090 (on by default). Set
             # OTEL_TRACES_EXPORTER=console/otlp to also emit spans (off by default).
             - name: OTEL_TRACES_EXPORTER
@@ -354,6 +359,11 @@ spec:
               value: "false"
             - name: CSI_MAJOR_VERSION
               value: "1"
+            # Log verbosity: panic, fatal, error, warn, info, debug, trace.
+            # debug logs every Anvil REST call — use it for troubleshooting,
+            # not steady-state operation.
+            - name: LOG_LEVEL
+              value: "info"
             # OTel toggles. hostNetwork=true means we bind directly to the
             # node's :9091 (must differ from controller's :9090 in case the
             # controller lands on the same node).

--- a/deploy/kubernetes/kubernetes-1.35/plugin.yaml
+++ b/deploy/kubernetes/kubernetes-1.35/plugin.yaml
@@ -156,6 +156,11 @@ spec:
               value: "false"
             - name: CSI_MAJOR_VERSION
               value: "1"
+            # Log verbosity: panic, fatal, error, warn, info, debug, trace.
+            # debug logs every Anvil REST call — use it for troubleshooting,
+            # not steady-state operation.
+            - name: LOG_LEVEL
+              value: "info"
             # OTel toggles — Prometheus /metrics on :9090 (on by default). Set
             # OTEL_TRACES_EXPORTER=console/otlp to also emit spans (off by default).
             - name: OTEL_TRACES_EXPORTER
@@ -354,6 +359,11 @@ spec:
               value: "false"
             - name: CSI_MAJOR_VERSION
               value: "1"
+            # Log verbosity: panic, fatal, error, warn, info, debug, trace.
+            # debug logs every Anvil REST call — use it for troubleshooting,
+            # not steady-state operation.
+            - name: LOG_LEVEL
+              value: "info"
             # OTel toggles. hostNetwork=true means we bind directly to the
             # node's :9091 (must differ from controller's :9090 in case the
             # controller lands on the same node).

--- a/deploy/kubernetes/kubernetes-1.36/plugin.yaml
+++ b/deploy/kubernetes/kubernetes-1.36/plugin.yaml
@@ -156,6 +156,11 @@ spec:
               value: "false"
             - name: CSI_MAJOR_VERSION
               value: "1"
+            # Log verbosity: panic, fatal, error, warn, info, debug, trace.
+            # debug logs every Anvil REST call — use it for troubleshooting,
+            # not steady-state operation.
+            - name: LOG_LEVEL
+              value: "info"
             # OTel toggles — Prometheus /metrics on :9090 (on by default). Set
             # OTEL_TRACES_EXPORTER=console/otlp to also emit spans (off by default).
             - name: OTEL_TRACES_EXPORTER
@@ -354,6 +359,11 @@ spec:
               value: "false"
             - name: CSI_MAJOR_VERSION
               value: "1"
+            # Log verbosity: panic, fatal, error, warn, info, debug, trace.
+            # debug logs every Anvil REST call — use it for troubleshooting,
+            # not steady-state operation.
+            - name: LOG_LEVEL
+              value: "info"
             # OTel toggles. hostNetwork=true means we bind directly to the
             # node's :9091 (must differ from controller's :9090 in case the
             # controller lands on the same node).

--- a/main.go
+++ b/main.go
@@ -43,6 +43,9 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
+// DefaultLogLevel is the level used when LOG_LEVEL is unset or invalid.
+const DefaultLogLevel = log.InfoLevel
+
 func init() {
 	// Setup logging
 	log.SetFormatter(&log.JSONFormatter{
@@ -51,12 +54,31 @@ func init() {
 		TimestampFormat:  "2006-01-02 15:04:05",
 	})
 	log.SetOutput(os.Stdout)
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(parseLogLevel(os.Getenv("LOG_LEVEL")))
 	log.SetReportCaller(false)
 	// Initialize OpenTelemetry (traces + metrics), configured via env vars.
 	if err := initTelemetry(); err != nil {
 		log.Fatalf("failed to init telemetry: %v", err)
 	}
+}
+
+// parseLogLevel resolves the LOG_LEVEL environment variable to a log level,
+// accepting the usual names (panic, fatal, error, warn, info, debug, trace).
+// An unset or unparseable value falls back to info.
+//
+// Note that debug logs every Anvil REST call, so it is verbose under load and
+// is intended for troubleshooting rather than steady-state operation.
+func parseLogLevel(level string) log.Level {
+	level = strings.TrimSpace(level)
+	if level == "" {
+		return DefaultLogLevel
+	}
+	parsed, err := log.ParseLevel(level)
+	if err != nil {
+		log.Warnf("invalid LOG_LEVEL %q, defaulting to %s", level, DefaultLogLevel)
+		return DefaultLogLevel
+	}
+	return parsed
 }
 
 // initTelemetry wires OTel providers according to standard env vars:

--- a/main.go
+++ b/main.go
@@ -47,9 +47,11 @@ import (
 const DefaultLogLevel = log.InfoLevel
 
 func init() {
-	// Setup logging
+	// Setup logging. Emit one JSON object per line: log collectors (Loki, ELK,
+	// CloudWatch) parse container output line by line, so indented multi-line
+	// JSON is read as several unparseable fragments per entry.
 	log.SetFormatter(&log.JSONFormatter{
-		PrettyPrint:      true,
+		PrettyPrint:      false,
 		DisableTimestamp: false,
 		TimestampFormat:  "2006-01-02 15:04:05",
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 Hammerspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  log.Level
+	}{
+		{"unset falls back to default", "", DefaultLogLevel},
+		{"whitespace only falls back to default", "   ", DefaultLogLevel},
+		{"invalid value falls back to default", "chatty", DefaultLogLevel},
+		{"info", "info", log.InfoLevel},
+		{"debug", "debug", log.DebugLevel},
+		{"warn", "warn", log.WarnLevel},
+		{"error", "error", log.ErrorLevel},
+		{"trace", "trace", log.TraceLevel},
+		{"uppercase is accepted", "DEBUG", log.DebugLevel},
+		{"surrounding whitespace is trimmed", "  debug  ", log.DebugLevel},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseLogLevel(tc.input); got != tc.want {
+				t.Errorf("parseLogLevel(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// The driver must not default to debug: debug logs every Anvil REST call, which
+// is far too verbose for steady-state operation.
+func TestDefaultLogLevelIsNotDebug(t *testing.T) {
+	if DefaultLogLevel >= log.DebugLevel {
+		t.Errorf("DefaultLogLevel = %v, want a level less verbose than debug", DefaultLogLevel)
+	}
+}

--- a/pkg/client/hsclient.go
+++ b/pkg/client/hsclient.go
@@ -348,9 +348,9 @@ func (client *HammerspaceClient) generateRequest(ctx context.Context, verb, urlP
 
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if !spanCtx.IsValid() {
-		log.Warn("No active span context found in ctx")
+		log.Debug("No active span context found in ctx")
 	} else {
-		log.Infof("trace: method=%s url=%s trace_id=%s span_id=%s",
+		log.Debugf("trace: method=%s url=%s trace_id=%s span_id=%s",
 			req.Method,
 			req.URL.String(),
 			spanCtx.TraceID().String(),
@@ -622,7 +622,7 @@ func (client *HammerspaceClient) ListSnapshots(ctx context.Context, snapshot_id,
 			shareSnapshots = append(shareSnapshots, snapshot)
 		}
 	}
-	log.Infof("%v, %s, %s", shareSnapshots, snapshot_id, volume_id)
+	log.Debugf("ListSnapshots: shareSnapshots=%v snapshot_id=%s volume_id=%s", shareSnapshots, snapshot_id, volume_id)
 	return shareSnapshots, nil
 }
 
@@ -714,7 +714,7 @@ func (client *HammerspaceClient) CreateShare(ctx context.Context,
 	comment string) error {
 	defer common.MeasureOp(ctx, "HammerspaceClient.CreateShare")(nil)
 
-	log.Debug("Creating share: " + name)
+	log.Info("Creating share: " + name)
 	extendedInfo := common.GetCommonExtendedInfo()
 	if exportOptions == nil { // send empty list to api req
 		exportOptions = make([]common.ShareExportOptions, 0)
@@ -901,7 +901,7 @@ func (client *HammerspaceClient) CheckIfShareCreateTaskIsRunning(ctx context.Con
 // Set objectives on a share, at the specified path, optionally clearing previously-set objectives at the path
 // The path must start with a slash
 func (client *HammerspaceClient) SetObjectives(ctx context.Context, shareName string, path string, objectives []string) error {
-	log.Debugf("Setting objectives. Share=%s, Path=%s, Objectives=%v: ", shareName, path, objectives)
+	log.Infof("Setting objectives. Share=%s, Path=%s, Objectives=%v: ", shareName, path, objectives)
 	// Set objectives on share at path
 
 	for _, objectiveName := range objectives {
@@ -936,7 +936,7 @@ func (client *HammerspaceClient) SetObjectives(ctx context.Context, shareName st
 // size in bytes
 func (client *HammerspaceClient) UpdateShareSize(ctx context.Context, name string, size int64) error {
 
-	log.Debugf("Update share size : %s to %v", name, size)
+	log.Infof("Update share size : %s to %v", name, size)
 
 	share, err := client.GetShareRawFields(ctx, name)
 	if err != nil {
@@ -985,7 +985,7 @@ func (client *HammerspaceClient) UpdateShareSize(ctx context.Context, name strin
 
 func (client *HammerspaceClient) DeleteShare(ctx context.Context, name string, deleteDelay int64) error {
 	queryParams := "?delete-path=true"
-	log.Debugf("Deleting share: %s with delete delay %d", name, deleteDelay)
+	log.Infof("Deleting share: %s with delete delay %d", name, deleteDelay)
 	trace.SpanFromContext(ctx).SetAttributes(
 		attribute.String("share.name", name),
 		attribute.Int64("share.delete_delay", deleteDelay),

--- a/pkg/common/host_utils.go
+++ b/pkg/common/host_utils.go
@@ -490,7 +490,7 @@ func determineBackingFileFromLoopDevice(lodevice string) (string, error) {
 // Note that this function does not work in Alpine image due to
 // losetup cutting the output off at 79 characters
 func determineLoopDeviceFromBackingFile(backingfile string) (string, error) {
-	log.Infof("determine loop device from backing file: '%s'", backingfile)
+	log.Debugf("determine loop device from backing file: '%s'", backingfile)
 	output, err := ExecCommand("losetup", "-a")
 	if err != nil {
 		return "", status.Errorf(codes.Internal,
@@ -501,7 +501,7 @@ func determineLoopDeviceFromBackingFile(backingfile string) (string, error) {
 		if d != "" {
 			device := strings.Split(d, " ")
 			if backingfile == strings.Trim(device[2], ":()") {
-				log.Infof("matched loop dev: '%s'", strings.Trim(device[0], ":()"))
+				log.Debugf("matched loop dev: '%s'", strings.Trim(device[0], ":()"))
 				return strings.Trim(device[0], ":()"), nil
 			}
 		}
@@ -610,7 +610,7 @@ func CheckNFSExports(address string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 
-	log.Infof("Checking floating ip %s", address)
+	log.Debugf("Checking floating ip %s", address)
 
 	uaddr, protocol, err := computeUaddr(address, 2049)
 	if err != nil {
@@ -626,7 +626,7 @@ func CheckNFSExports(address string) (bool, error) {
 			errChan <- err
 			return
 		}
-		log.Infof("Check was success on uaddr %s, with protocol %s.", uaddr, protocol)
+		log.Debugf("Check was success on uaddr %s, with protocol %s.", uaddr, protocol)
 		outputChan <- output
 	}()
 
@@ -637,7 +637,7 @@ func CheckNFSExports(address string) (bool, error) {
 	case err := <-errChan:
 		return false, status.Errorf(codes.Internal, "could not determine nfs exports: %v", err)
 	case output := <-outputChan:
-		log.Infof("%s", string(output))
+		log.Debugf("%s", string(output))
 		return true, nil
 	}
 }

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -351,7 +351,7 @@ func (d *CSIDriver) ensureShareBackedVolumeExists(ctx context.Context, hsVolume 
 	if err != nil {
 		log.Warnf("failed to get share backed volume on hsVolumePath %s targetPath %s. Err %v", hsVolume.Path, targetPath, err)
 	}
-	log.Debugf("Published share backed volume %s on targetpath %s", hsVolume.Path, targetPath)
+	log.Infof("Published share backed volume %s on targetpath %s", hsVolume.Path, targetPath)
 
 	// The hs client expects a trailing slash for directories
 	err = common.SetMetadataTags(ctx, targetPath+"/", hsVolume.AdditionalMetadataTags)
@@ -392,7 +392,7 @@ func (d *CSIDriver) ensureBackingShareExists(ctx context.Context, backingShareNa
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "%s", err.Error())
 		}
-		log.Infof("Checking if get share response back non nil share.")
+		log.Debugf("Checking if get share response back non nil share.")
 		if share == nil {
 			log.Errorf("Error while creating share from ensure backing share exist method.")
 			return nil, fmt.Errorf("requested share [%s] not found", backingShareName)
@@ -488,7 +488,7 @@ func (d *CSIDriver) ensureDeviceFileExists(ctx context.Context, backingShare *co
 				return err
 			}
 		}
-		log.Debugf("ensureDeviceFileExists formatted file %s, with fstype %s", deviceFile, hsVolume.FSType)
+		log.Infof("ensureDeviceFileExists formatted file %s, with fstype %s", deviceFile, hsVolume.FSType)
 	}
 
 	// Step 4: Apply objectives + metadata on a fresh deadline, but inherit
@@ -755,7 +755,7 @@ func (d *CSIDriver) CreateVolume(ctx context.Context, req *csi.CreateVolumeReque
 				return nil, status.Error(codes.Internal, "unexpected type for free capacity")
 			}
 		} else {
-			log.Infof("getting free capacity from (/cntl/state) api response")
+			log.Debugf("getting free capacity from (/cntl/state) api response")
 			// Call your function to get the free capacity from the API response here
 			available, err = d.hsclient.GetClusterAvailableCapacity(ctx)
 			if err != nil {
@@ -827,7 +827,7 @@ func (d *CSIDriver) CreateVolume(ctx context.Context, req *csi.CreateVolumeReque
 
 	if !fileBacked && fsType == "nfs" && vParams.MountBackingShareName != "" {
 		// This function is called when user want new nfs share inside one base share
-		log.Debugf("Creating share for NFS volume inside base NFS share dir %s with path %s", vParams.MountBackingShareName, hsVolume.Path)
+		log.Infof("Creating share for NFS volume inside base NFS share dir %s with path %s", vParams.MountBackingShareName, hsVolume.Path)
 		err := d.ensureNFSDirectoryExists(ctx, backingShareName, hsVolume)
 		if err != nil {
 			log.Errorf("failed to ensure base NFS share (%s): %v", backingShareName, err)
@@ -838,7 +838,7 @@ func (d *CSIDriver) CreateVolume(ctx context.Context, req *csi.CreateVolumeReque
 		volID = fmt.Sprintf("%s/%s", volumePath, volumeName)
 	} else if fileBacked {
 		// This function will be called in case of Block and File backed share
-		log.Debugf("Creating share for File system volume (block or files) inside base backingshare name dir %s with path %s", backingShareName, hsVolume.Path)
+		log.Infof("Creating share for File system volume (block or files) inside base backingshare name dir %s with path %s", backingShareName, hsVolume.Path)
 		err = d.ensureFileBackedVolumeExists(ctx, hsVolume, backingShareName)
 		if err != nil {
 			return nil, err
@@ -851,7 +851,7 @@ func (d *CSIDriver) CreateVolume(ctx context.Context, req *csi.CreateVolumeReque
 		// In that case all new created share will have path like /k8s-nfs-share/pvc-csi-uuid
 		// Then we create snapshot of that share /pvc-csi-uuid which will be inside /k8s-nfs-share/.snapshot
 		// Then restore the snapshot to the new created share from snapshot content source.
-		log.Debugf("Creating share for NFS volume with path %s", hsVolume.Path)
+		log.Infof("Creating share for NFS volume with path %s", hsVolume.Path)
 		err = d.ensureShareBackedVolumeExists(ctx, hsVolume)
 		if err != nil {
 			return nil, err
@@ -904,7 +904,7 @@ func (d *CSIDriver) deleteFileBackedVolume(ctx context.Context, filepath string)
 	defer span.End()
 	var exists bool
 	if exists, _ = d.hsclient.DoesFileExist(ctx, filepath); exists {
-		log.Debugf("found file-backed volume to delete, %s", filepath)
+		log.Infof("found file-backed volume to delete, %s", filepath)
 	}
 
 	// Check if file has snapshots and fail
@@ -1094,7 +1094,7 @@ func (d *CSIDriver) ControllerExpandVolume(ctx context.Context, req *csi.Control
 		if file == nil || err != nil {
 			return nil, status.Error(codes.NotFound, common.VolumeNotFound)
 		} else {
-			log.Debugf("found file-backed volume to resize, %s", req.GetVolumeId())
+			log.Infof("found file-backed volume to resize, %s", req.GetVolumeId())
 			// Check backing share size to determine if we can handle new size (look at create volume for how we do this)
 			// && check the size of the file only resize if requested is larger than what we have
 			// if we are good, then return saying we need a resize on next mount
@@ -1210,9 +1210,9 @@ func (d *CSIDriver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Val
 	}
 
 	if fileBacked {
-		log.Infof("Validating volume capabilities for file-backed volume %s", volumeName)
+		log.Debugf("Validating volume capabilities for file-backed volume %s", volumeName)
 	} else if share != nil {
-		log.Infof("Validating volume capabilities for share-backed volume %s", volumeName)
+		log.Debugf("Validating volume capabilities for share-backed volume %s", volumeName)
 	}
 
 	// Calculate Capabilties

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -281,7 +281,7 @@ func (d *CSIDriver) EnsureBackingShareMounted(ctx context.Context, backingShareN
 		// under other in-flight file-backed pods (the same outage this path is
 		// meant to prevent, via a false positive).
 		state := classifyMount(backingDir, mountStaleProbes, common.SafeIsMountPoint)
-		log.Infof("Checked mount for %s: state=%d", backingDir, state)
+		log.Debugf("Checked mount for %s: state=%d", backingDir, state)
 		switch state {
 		case mountHealthy:
 			log.Infof("backing share already mounted, %s", backingDir)
@@ -440,7 +440,7 @@ func (d *CSIDriver) UnmountBackingShareIfUnused(ctx context.Context, backingShar
 	))
 	defer span.End()
 	defer common.MeasureOp(ctx, "UnmountBackingShareIfUnused")(nil)
-	log.Infof("UnmountBackingShareIfUnused is called with backing share name %s", backingShareName)
+	log.Debugf("UnmountBackingShareIfUnused is called with backing share name %s", backingShareName)
 	backingShare, err := d.hsclient.GetShare(ctx, backingShareName)
 	if err != nil || backingShare == nil {
 		log.Errorf("unable to get share while checking UnmountBackingShareIfUnused. Err %v", err)
@@ -498,7 +498,7 @@ func (d *CSIDriver) MountShareAtBestDataportal(ctx context.Context, shareExportP
 	var err error
 	var fipaddr string = ""
 
-	log.Infof("Finding best host exporting %s", shareExportPath)
+	log.Debugf("Finding best host exporting %s", shareExportPath)
 
 	portals, err := d.hsclient.GetDataPortals(ctx, d.NodeID)
 	if err != nil {
@@ -549,7 +549,7 @@ func (d *CSIDriver) MountShareAtBestDataportal(ctx context.Context, shareExportP
 		addr := ""
 		if len(fipaddr) > 0 {
 			addr = fipaddr
-			log.Infof("Floating IP address detected: %s", fipaddr)
+			log.Debugf("Floating IP address detected: %s", fipaddr)
 		} else {
 			addr = portal.Node.MgmtIpAddress.Address
 		}
@@ -562,10 +562,10 @@ func (d *CSIDriver) MountShareAtBestDataportal(ctx context.Context, shareExportP
 			exports, err := common.GetNFSExports(addr)
 			common.SetCacheData("NFS_EXPORTS", exports, 60*60) // keep the exports for an our before auto expire
 			if err != nil {
-				log.Infof("Could not get exports for data-portal at %s, %s. Error: %v", addr, portal.Uoid["uuid"], err)
+				log.Debugf("Could not get exports for data-portal at %s, %s. Error: %v", addr, portal.Uoid["uuid"], err)
 				return false
 			}
-			log.Infof("Found exports for data-portal %s, %v", addr, exports)
+			log.Debugf("Found exports for data-portal %s, %v", addr, exports)
 
 			// Check configured prefix
 			// Check the default prefixes
@@ -573,7 +573,7 @@ func (d *CSIDriver) MountShareAtBestDataportal(ctx context.Context, shareExportP
 				for _, e := range exports {
 					if e == fmt.Sprintf("%s%s", mountPrefix, shareExportPath) {
 						export = fmt.Sprintf("%s:%s%s", addr, mountPrefix, shareExportPath)
-						log.Infof("Found export %s", export)
+						log.Debugf("Found export %s", export)
 						break
 					}
 				}
@@ -582,7 +582,7 @@ func (d *CSIDriver) MountShareAtBestDataportal(ctx context.Context, shareExportP
 				}
 			}
 			if export == "" {
-				log.Infof("Could not find any matching export on data-portal address - %s uuid - %s.", portal.Node.MgmtIpAddress.Address, portal.Uoid["uuid"])
+				log.Debugf("Could not find any matching export on data-portal address - %s uuid - %s.", portal.Node.MgmtIpAddress.Address, portal.Uoid["uuid"])
 				return false
 			}
 		}
@@ -611,7 +611,7 @@ func (d *CSIDriver) MountShareAtBestDataportal(ctx context.Context, shareExportP
 		return false
 	}
 
-	log.Infof("Attempting to mount with provided mount flags.")
+	log.Debugf("Attempting to mount with provided mount flags.")
 	// Attempt to mount with provided mount flags if they contain nfsvers
 	containsNfsvers := false
 	for _, flag := range mountFlags {


### PR DESCRIPTION
Makes driver log verbosity configurable and gives INFO a usable default.

- **`LOG_LEVEL` env var** (added to the 1.34–1.36 manifests) and the default log level changed from **debug → info**.
- **Single-line JSON logs** for easier ingestion.
- **Re-leveled log statements** so the new INFO default is meaningful rather than whatever level each line happened to use:
  - Demoted to DEBUG: per-request trace lines, loop-device matching, floating-IP health checks, raw command output, capacity-API internals, and assorted "checking…" chatter.
  - Promoted to INFO: provisioning lifecycle — creating / resizing / deleting a share, setting objectives, publishing a volume, formatting a backing file, finding a volume to delete.

Supersedes the `feature/configurable-log-level` branch (this is that work plus the re-leveling pass).

> ⚠️ **Draft / do-not-merge-yet:** the debug → info default change needs an INFO-vs-DEBUG comparison on a live cluster to confirm INFO carries enough signal to troubleshoot without DEBUG. Marking ready for review once that validation is done.
